### PR TITLE
BUGFIX CarouselPageExtension - IntervalInMilliseconds

### DIFF
--- a/src/Extension/CarouselPageExtension.php
+++ b/src/Extension/CarouselPageExtension.php
@@ -145,7 +145,7 @@ class CarouselPageExtension extends DataExtension
     {
         $interval = $this->owner->Interval;
         if (!$this->owner->Interval || $this->owner->Interval < 0) {
-            $interval = self::$defaults['Inverval'];
+            $interval = self::$defaults['Interval'];
         }
         return (int) $interval * 1000;
     }


### PR DESCRIPTION
correct misspelling when referencing the class default Interval value.

fixes #16