### PR TITLE
Complete GitHub Sponsors integration - Add badge and composer funding

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,9 @@
 
 A versatile carousel module for Silverstripe websites, featuring support for images and videos. The default template utilizes Bootstrap classes for seamless integration.
 
-[![CI](https://github.com/dynamic/silverstripe-carousel/workflows/CI/badge.svg)](https://github.com/dynamic/silverstripe-carousel/actions)  
-[![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-carousel/v/stable)](https://packagist.org/packages/dynamic/silverstripe-carousel)  
-[![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-carousel/downloads)](https://packagist.org/packages/dynamic/silverstripe-carousel)  
-[![License](https://poser.pugx.org/dynamic/silverstripe-carousel/license)](https://packagist.org/packages/dynamic/silverstripe-carousel)  
+[![CI](https://github.com/dynamic/silverstripe-carousel/workflows/CI/badge.svg)](https://github.com/dynamic/silverstripe-carousel/actions) [![Sponsor](https://img.shields.io/badge/Sponsor-Dynamic-brightgreen)](https://github.com/sponsors/dynamic)
 
-[![Sponsor](https://img.shields.io/badge/Sponsor-Dynamic-brightgreen)](https://github.com/sponsors/dynamic)
+[![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-carousel/v/stable)](https://packagist.org/packages/dynamic/silverstripe-carousel) [![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-carousel/downloads)](https://packagist.org/packages/dynamic/silverstripe-carousel) [![Latest Unstable Version](https://poser.pugx.org/dynamic/silverstripe-carousel/v/unstable)](https://packagist.org/packages/dynamic/silverstripe-carousel) [![License](https://poser.pugx.org/dynamic/silverstripe-carousel/license)](https://packagist.org/packages/dynamic/silverstripe-carousel)
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A versatile carousel module for Silverstripe websites, featuring support for ima
 [![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-carousel/downloads)](https://packagist.org/packages/dynamic/silverstripe-carousel)  
 [![License](https://poser.pugx.org/dynamic/silverstripe-carousel/license)](https://packagist.org/packages/dynamic/silverstripe-carousel)  
 
+[![Sponsor](https://img.shields.io/badge/Sponsor-Dynamic-brightgreen)](https://github.com/sponsors/dynamic)
+
 ## Table of Contents
 
 - [Requirements](#requirements)
@@ -100,7 +102,7 @@ If you're not using Bootstrap or wish to customize the carousel's appearance:
    ```
 
 2. **Copy to Your Theme**  
-   Copy the `Carousel.ss` file to your theme’s directory, maintaining the folder structure:  
+   Copy the `Carousel.ss` file to your theme's directory, maintaining the folder structure:  
    ```
    themes/your-theme/templates/Dynamic/Carousel/Includes/Carousel.ss
    ```

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,12 @@
             "Dynamic\\Carousel\\Test\\": "tests/"
         }
     },
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/dynamic"
+        }
+    ],
     "extra": {
         "branch-alias": {
             "dev-main": "2.x-dev"


### PR DESCRIPTION
This PR completes the GitHub Sponsors integration that was partially implemented in PR #41.

## Changes
- Add Sponsors badge to README.md (after license badge)
- Add `funding` field to composer.json pointing to https://github.com/sponsors/dynamic

## Context
PR #41 added the `.github/FUNDING.yml` file but did not update the README badge or composer.json funding field. This PR completes the integration to match the other repositories in the organization.