### PR TITLE
Upgrade to SilverStripe 6

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: dynamic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,3 @@ jobs:
   ci:
     name: CI
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
-    with:
-      phpcoverage: true

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 A versatile carousel module for Silverstripe websites, featuring support for images and videos. The default template utilizes Bootstrap classes for seamless integration.
 
-[![CI](https://github.com/dynamic/silverstripe-carousel/workflows/CI/badge.svg)](https://github.com/dynamic/silverstripe-carousel/actions)  
-[![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-carousel/v/stable)](https://packagist.org/packages/dynamic/silverstripe-carousel)  
-[![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-carousel/downloads)](https://packagist.org/packages/dynamic/silverstripe-carousel)  
-[![License](https://poser.pugx.org/dynamic/silverstripe-carousel/license)](https://packagist.org/packages/dynamic/silverstripe-carousel)  
+[![CI](https://github.com/dynamic/silverstripe-carousel/workflows/CI/badge.svg)](https://github.com/dynamic/silverstripe-carousel/actions) [![Sponsor](https://img.shields.io/badge/Sponsor-Dynamic-brightgreen)](https://github.com/sponsors/dynamic)
+
+[![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-carousel/v/stable)](https://packagist.org/packages/dynamic/silverstripe-carousel) [![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-carousel/downloads)](https://packagist.org/packages/dynamic/silverstripe-carousel) [![Latest Unstable Version](https://poser.pugx.org/dynamic/silverstripe-carousel/v/unstable)](https://packagist.org/packages/dynamic/silverstripe-carousel) [![License](https://poser.pugx.org/dynamic/silverstripe-carousel/license)](https://packagist.org/packages/dynamic/silverstripe-carousel)
 
 ## Table of Contents
 
@@ -100,7 +99,7 @@ If you're not using Bootstrap or wish to customize the carousel's appearance:
    ```
 
 2. **Copy to Your Theme**  
-   Copy the `Carousel.ss` file to your theme’s directory, maintaining the folder structure:  
+   Copy the `Carousel.ss` file to your theme's directory, maintaining the folder structure:  
    ```
    themes/your-theme/templates/Dynamic/Carousel/Includes/Carousel.ss
    ```

--- a/README.md
+++ b/README.md
@@ -1,30 +1,50 @@
 # Silverstripe Carousel
 
-A simple carousel for Silverstripe websites. The default template uses Bootstrap classes to power the carousel. If you are not using Bootstrap, you can use a custom template and include your own javascript.
+A versatile carousel module for Silverstripe websites, featuring support for images and videos. The default template utilizes Bootstrap classes for seamless integration.
 
-![CI](https://github.com/dynamic/silverstripe-carousel/workflows/CI/badge.svg)
-[![codecov](https://codecov.io/gh/dynamic/silverstripe-carousel/branch/master/graph/badge.svg)](https://codecov.io/gh/dynamic/silverstripe-carousel)
+[![CI](https://github.com/dynamic/silverstripe-carousel/workflows/CI/badge.svg)](https://github.com/dynamic/silverstripe-carousel/actions)  
+[![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-carousel/v/stable)](https://packagist.org/packages/dynamic/silverstripe-carousel)  
+[![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-carousel/downloads)](https://packagist.org/packages/dynamic/silverstripe-carousel)  
+[![License](https://poser.pugx.org/dynamic/silverstripe-carousel/license)](https://packagist.org/packages/dynamic/silverstripe-carousel)  
 
-[![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-carousel/v/stable)](https://packagist.org/packages/dynamic/silverstripe-carousel)
-[![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-carousel/downloads)](https://packagist.org/packages/dynamic/silverstripe-carousel)
-[![Latest Unstable Version](https://poser.pugx.org/dynamic/silverstripe-carousel/v/unstable)](https://packagist.org/packages/dynamic/silverstripe-carousel)
-[![License](https://poser.pugx.org/dynamic/silverstripe-carousel/license)](https://packagist.org/packages/dynamic/silverstripe-carousel)
+## Table of Contents
+
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Usage](#usage)
+  - [Adding a Carousel to a Page](#adding-a-carousel-to-a-page)
+  - [Working with Images and Videos](#working-with-images-and-videos)
+- [Customization](#customization)
+  - [Creating Custom Templates](#creating-custom-templates)
+- [Other Modules Using Silverstripe Carousel](#other-modules-using-silverstripe-carousel)
+- [Maintainers](#maintainers)
+- [Bugtracker](#bugtracker)
+- [Development and Contribution](#development-and-contribution)
+- [License](#license)
 
 ## Requirements
 
-- Silverstripe CMS ^5
+- Silverstripe CMS ^5.0
+- Bootstrap 5 (for default templates)
 
 ## Installation
 
-`composer require dynamic/silverstripe-carousel`
+Install via Composer:
 
-## License
+```sh
+composer require dynamic/silverstripe-carousel
+```
 
-See [License](LICENSE.md)
+Run a dev/build to regenerate the manifest:
 
-## Usage
+```sh
+./vendor/bin/sake dev/build
+```
 
-To add a carousel to a page, apply `CarouselPageExtension` to a page type:
+## Configuration
+
+Apply the `CarouselPageExtension` to your desired page types in your YAML configuration:
 
 ```yaml
 Page:
@@ -32,35 +52,103 @@ Page:
     - Dynamic\Carousel\Extension\CarouselPageExtension
 ```
 
-In your template, include the `Carousel` template:
+After applying the extension, run a dev/build to update the database schema.
 
-```html
-<% include Dynamic/Carousel/Carousel %> 
+## Usage
+
+### Adding a Carousel to a Page
+
+To display the carousel, include the following template in your page layout:
+
+```ss
+<% include Dynamic/Carousel/Includes/Carousel %>
 ```
 
-### Template Notes
+Ensure that your template has access to the `$Carousel` variable, which contains the carousel data.
 
-The default template assumes you are using [Bootstrap 5](https://getbootstrap.com/), and requires no additional javascript. If you are not using Bootstrap, you can use a custom template and include your own javascript.
+### Working with Images and Videos
 
-Note - if you are not including all of Bootstrap, you will need to manually include the carousel component.
+The module supports two types of content:
 
+- **Images**: For displaying images.
+- **Videos**: For embedding videos.
+
+To add these:
+
+1. In the CMS, navigate to the page where you've enabled the carousel.
+2. Click on the "Carousel" tab.
+3. Use the "Add Slide" button to add either an Image or Video.
+4. For Images:
+   - Upload or select an image from the files.
+   - Optionally, add a caption or link.
+5. For Videos:
+   - Provide the video URL (supports platforms like YouTube and Vimeo).
+   - Optionally, add a caption.
+
+Repeat these steps to add multiple images or videos as needed.
+
+## Customization
+
+### Creating Custom Templates
+
+If you're not using Bootstrap or wish to customize the carousel's appearance:
+
+1. **Locate the Default Template**  
+   The default template is located at:  
+   ```
+   templates/Dynamic/Carousel/Includes/Carousel.ss
+   ```
+
+2. **Copy to Your Theme**  
+   Copy the `Carousel.ss` file to your theme’s directory, maintaining the folder structure:  
+   ```
+   themes/your-theme/templates/Dynamic/Carousel/Includes/Carousel.ss
+   ```
+
+3. **Modify the Template**  
+   Edit the copied `Carousel.ss` to fit your design requirements. You can:  
+   - Change the HTML structure  
+   - Update CSS classes  
+   - Add or remove elements as needed  
+
+4. **Include Necessary Assets**  
+   Ensure that any required JavaScript or CSS for your custom carousel implementation is included in your project.  
+   If you're using a different frontend framework, include its assets accordingly.
+
+For more information on custom templates, refer to the [Silverstripe CMS Documentation](https://docs.silverstripe.org/en/5/developer_guides/templates/).
+
+## Other Modules Using Silverstripe Carousel
+
+The Silverstripe Carousel module is used in other projects to extend functionality, such as:
+
+- [Silverstripe Elemental Carousel](https://github.com/dynamic/silverstripe-elemental-carousel) - Integrates carousel functionality with Silverstripe Elemental Blocks.
 
 ## Maintainers
- *  [Dynamic](http://www.dynamicagency.com) (<dev@dynamicagency.com>)
+
+- [Dynamic](http://www.dynamicagency.com) (<dev@dynamicagency.com>)
 
 ## Bugtracker
-Bugs are tracked in the issues section of this repository. Before submitting an issue please read over
-existing issues to ensure yours is unique.
 
-If the issue does look like a new bug:
+Bugs are tracked in the issues section of this repository. Before submitting an issue, please review existing issues to ensure yours is unique.
 
- - Create a new issue
- - Describe the steps required to reproduce your issue, and the expected outcome. Unit tests, screenshots
- and screencasts can help here.
- - Describe your environment as detailed as possible: SilverStripe version, Browser, PHP version,
- Operating System, any installed SilverStripe modules.
+If the issue appears to be new:
 
-Please report security issues to the module maintainers directly. Please don't file security issues in the bugtracker.
+- Create a new issue.
+- Describe the steps required to reproduce your issue and the expected outcome. Unit tests, screenshots, and screencasts can help here.
+- Provide details about your environment:
+  - Silverstripe version
+  - Browser and version
+  - PHP version
+  - Operating system
+  - Any installed Silverstripe modules
 
-## Development and contribution
-If you would like to make contributions to the module please ensure you raise a pull request and discuss with the module maintainers.
+**Security Issues:**  
+Please report security issues to the module maintainers directly. Avoid filing security issues in the bugtracker.
+
+## Development and Contribution
+
+We welcome contributions! Please ensure you raise a pull request and discuss with the module maintainers.
+
+## License
+
+This module is licensed under the BSD-3-Clause License. See the [LICENSE](LICENSE.md) file for details.

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,11 @@
     ],
     "require": {
         "jonom/focuspoint": "^5",
-        "silverstripe/linkfield":"^4.0",
+        "nathancox/embedfield": "^3.0",
+        "silverstripe/linkfield": "^4.0",
         "silverstripe/recipe-cms": "^5.0",
-        "symbiote/silverstripe-gridfieldextensions": "^4"
+        "symbiote/silverstripe-gridfieldextensions": "^4",
+        "unclecheese/display-logic": "^3.0"
     },
     "require-dev": {
         "dnadesign/silverstripe-elemental": "^5",

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,12 @@
             "Dynamic\\Carousel\\Test\\": "tests/"
         }
     },
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/dynamic"
+        }
+    ],
     "extra": {
         "branch-alias": {
             "dev-main": "2.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require-dev": {
         "dnadesign/silverstripe-elemental": "^5",
         "silverstripe/recipe-testing": "^3",
-        "squizlabs/php_codesniffer": "^3.7"
+        "silverstripe/standards": "^1",
+        "squizlabs/php_codesniffer": "^3"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -8,16 +8,17 @@
         "CMS"
     ],
     "require": {
+        "php": "^8.1",
         "jonom/focuspoint": "^5",
         "nathancox/embedfield": "^3.0",
-        "silverstripe/linkfield": "^4.0",
-        "silverstripe/recipe-cms": "^5.0",
-        "symbiote/silverstripe-gridfieldextensions": "^4",
-        "unclecheese/display-logic": "^3.0"
+        "silverstripe/linkfield": "^5.0",
+        "silverstripe/recipe-cms": "^6.0",
+        "symbiote/silverstripe-gridfieldextensions": "^5",
+        "unclecheese/display-logic": "^4.0"
     },
     "require-dev": {
-        "dnadesign/silverstripe-elemental": "^5",
-        "silverstripe/recipe-testing": "^3",
+        "dnadesign/silverstripe-elemental": "^6",
+        "silverstripe/recipe-testing": "^6",
         "silverstripe/standards": "^1",
         "squizlabs/php_codesniffer": "^3"
     },
@@ -37,7 +38,7 @@
     ],
     "extra": {
         "branch-alias": {
-            "dev-main": "2.x-dev"
+            "dev-main": "3.x-dev"
         }
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,5 @@
+parameters:
+  level: 1
+  treatPhpDocTypesAsCertain: false
+  paths:
+    - src

--- a/src/Extension/CarouselPageExtension.php
+++ b/src/Extension/CarouselPageExtension.php
@@ -27,7 +27,7 @@ use SilverStripe\Forms\GridField\GridFieldAddExistingAutocompleter;
  * @property string $Transitions
  * @property string $Autoplay
  * @property int $Interval
- * @method ManyManyList|Slide[] Slides()
+ * @method \SilverStripe\ORM\ManyManyThroughList|Slide[] Slides()
  */
 class CarouselPageExtension extends DataExtension
 {

--- a/src/Extension/CarouselPageExtension.php
+++ b/src/Extension/CarouselPageExtension.php
@@ -73,6 +73,22 @@ class CarouselPageExtension extends DataExtension
      * @var array
      * @config
      */
+    private static $cascade_duplicates = [
+        'Slides',
+    ];
+
+    /**
+     * @var array
+     * @config
+     */
+    private static array $cascade_deletes = [
+        'Slides',
+    ];
+
+    /**
+     * @var array
+     * @config
+     */
     private static $defaults = [
         'Interval' => 5
     ];

--- a/src/Extension/CarouselPageExtension.php
+++ b/src/Extension/CarouselPageExtension.php
@@ -40,7 +40,7 @@ class CarouselPageExtension extends DataExtension
         'Indicators' => 'Enum("Off,On", "On")',
         'Transitions' => 'Enum("Slide,Fade", "Slide")',
         'Autoplay' => 'Enum("Off,Autoplay after interaction,On","Off")',
-        'Interval' => 'Int'
+        'Interval' => 'Int',
     ];
 
     /**
@@ -90,7 +90,7 @@ class CarouselPageExtension extends DataExtension
      * @config
      */
     private static $defaults = [
-        'Interval' => 5
+        'Interval' => 5,
     ];
 
     /**
@@ -147,13 +147,14 @@ class CarouselPageExtension extends DataExtension
     public function getCarouselSettings()
     {
         return FieldList::create(
-            DropdownField::create('Controls', 'Show Controls', $this->getOwner()->dbObject('Controls')->enumValues())
+            DropdownField::create('Controls', 'Show Controls')
+                ->setSource($this->getOwner()->dbObject('Controls')->enumValues())
                 ->setDescription('Previous/next arrows. Hidden if only one slide'),
-            DropdownField::create('Indicators', $this->getOwner()->dbObject('Indicators')->enumValues())
-                ->setTitle('Show Indicators')
+            DropdownField::create('Indicators', 'Show Indicators')
+                ->setSource($this->getOwner()->dbObject('Indicators')->enumValues())
                 ->setDescription(' Let users jump directly to a particular slide. Hidden if only one slide'),
-            DropdownField::create('Transitions', $this->getOwner()->dbObject('Transitions')->enumValues())
-                ->setTitle('Transitions'),
+            DropdownField::create('Transitions', 'Transitions')
+                ->setSource($this->getOwner()->dbObject('Transitions')->enumValues()),
             DropdownField::create('Autoplay', 'Autoplay', $this->getOwner()->dbObject('Autoplay')->enumValues()),
             NumericField::create('Interval')
                 ->setDescription('Time in seconds'),
@@ -180,7 +181,7 @@ class CarouselPageExtension extends DataExtension
         if (!$this->getOwner()->Interval || $this->getOwner()->Interval < 0) {
             $interval = self::$defaults['Interval'];
         }
-        return (int) $interval * 1000;
+        return (int)$interval * 1000;
     }
 
     /**

--- a/src/Extension/CarouselPageExtension.php
+++ b/src/Extension/CarouselPageExtension.php
@@ -65,6 +65,14 @@ class CarouselPageExtension extends DataExtension
      * @var array
      * @config
      */
+    private static $owns = [
+        'Slides',
+    ];
+
+    /**
+     * @var array
+     * @config
+     */
     private static $defaults = [
         'Interval' => 5
     ];

--- a/src/Model/ImageSlide.php
+++ b/src/Model/ImageSlide.php
@@ -4,8 +4,9 @@ namespace Dynamic\Carousel\Model;
 
 use SilverStripe\Assets\Image;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\LinkField\Form\LinkField;
 use SilverStripe\LinkField\Models\Link;
+use SilverStripe\LinkField\Form\LinkField;
+use SilverStripe\AssetAdmin\Forms\UploadField;
 
 /**
  * Class \Dynamic\Carousel\Model\ImageSlide
@@ -40,6 +41,7 @@ class ImageSlide extends Slide
      */
     private static $has_one = [
         'Image' => Image::class,
+        'ImageMobile' => Image::class,
         'ElementLink' => Link::class,
     ];
 
@@ -49,6 +51,7 @@ class ImageSlide extends Slide
      */
     private static $owns = [
         'Image',
+        'ImageMobile',
         'ElementLink',
     ];
 
@@ -82,6 +85,7 @@ class ImageSlide extends Slide
                 $link = LinkField::create('ElementLink')
                     ->setTitle($this->fieldLabel('ElementLink'))
             );
+            $link->setDescription('Optional. Leave blank to hide.');
 
             $fields->addFieldsToTab(
                 'Root.Main',
@@ -93,6 +97,21 @@ class ImageSlide extends Slide
                 ],
                 'Content'
             );
+
+            // Image for small screens
+            $fields->insertAfter(
+                'Image',
+                UploadField::create('ImageMobile', 'Image (for small screens)')
+                ->setFolderName('Uploads/Carousel/Slides')
+                ->setDescription('Optional.')
+            );
+
+            if (
+                $this->getOwner()->hasField('ParentID') &&
+                $this->getOwner()->Parent() instanceof \SilverStripe\CMS\Model\SiteTree
+            ) {
+                $fields->dataFieldByName('Image')->setDescription('Recommended size: 1920x823');
+            }
         });
 
         return parent::getCMSFields();

--- a/src/Model/ImageSlide.php
+++ b/src/Model/ImageSlide.php
@@ -90,7 +90,6 @@ class ImageSlide extends Slide
             $fields->addFieldsToTab(
                 'Root.Main',
                 [
-                    // @phpstan-ignore-next-line
                     $fields->dataFieldByName('Image')
                         ->setFolderName('Uploads/Carousel/Slides'),
                     $link

--- a/src/Model/Slide.php
+++ b/src/Model/Slide.php
@@ -134,6 +134,16 @@ class Slide extends DataObject
     }
 
     /**
+     * ShowCaption
+     */
+    public function ShowCaption(): bool
+    {
+        $owner = $this->getOwner();
+
+        return (($owner->Title && $owner->ShowTitle) || $owner->SubTitle || $owner->Content);
+    }
+
+    /**
      * Basic permissions, defaults to parent perms where possible.
      *
      * @param Member $member

--- a/src/Model/Slide.php
+++ b/src/Model/Slide.php
@@ -208,7 +208,6 @@ class Slide extends DataObject
         if ($this->Parent()->exists()) {
             $parent = $this->Parent();
             if ($parent->hasExtension(Versioned::class)) {
-                // @phpstan-ignore-next-line
                 return $parent->canArchive($member);
             } else {
                 return $parent->canDelete($member);

--- a/src/Model/Slide.php
+++ b/src/Model/Slide.php
@@ -18,9 +18,7 @@ use DNADesign\Elemental\Forms\TextCheckboxGroupField;
  * @property string $Title
  * @property bool $ShowTitle
  * @property string $Content
- * @property string $ParentClass
- * @property int $ParentID
- * @method DataObject Parent()
+ * @method \SilverStripe\ORM\ManyManyThroughList Parents()
  * @mixin Versioned
  */
 class Slide extends DataObject
@@ -51,15 +49,6 @@ class Slide extends DataObject
         'Title' => 'Varchar',
         'ShowTitle' => 'Boolean',
         'Content' => 'HTMLText',
-        'ParentClass' => 'Varchar',
-    ];
-
-    /**
-     * @var array
-     * @config
-     */
-    private static $has_one = [
-        'Parent' => DataObject::class,
     ];
 
     /**
@@ -144,7 +133,7 @@ class Slide extends DataObject
     }
 
     /**
-     * Basic permissions, defaults to parent perms where possible.
+     * Basic permissions - simplified since slides no longer have direct parent references
      *
      * @param Member $member
      * @return boolean
@@ -156,16 +145,11 @@ class Slide extends DataObject
             return $extended;
         }
 
-        if ($this->Parent()) {
-            $parent = $this->Parent();
-            return $parent->canView($member);
-        }
-
         return (Permission::check('CMS_ACCESS', 'any', $member)) ? true : null;
     }
 
     /**
-     * Basic permissions, defaults to parent perms where possible.
+     * Basic permissions - simplified since slides no longer have direct parent references
      *
      * @param Member $member
      *
@@ -178,20 +162,11 @@ class Slide extends DataObject
             return $extended;
         }
 
-        if ($this->Parent()) {
-            $parent = $this->Parent();
-            return $parent->canEdit($member);
-        }
-
         return (Permission::check('CMS_ACCESS', 'any', $member)) ? true : null;
     }
 
     /**
-     * Basic permissions, defaults to page perms where possible.
-     *
-     * Uses archive not delete so that current stage is respected i.e if a
-     * slide is not published, then it can be deleted by someone who doesn't
-     * have publishing permissions.
+     * Basic permissions - simplified since slides no longer have direct parent references
      *
      * @param Member $member
      *
@@ -200,19 +175,10 @@ class Slide extends DataObject
     public function canDelete($member = null)
     {
         $extended = $this->extendedCan(__FUNCTION__, $member);
-
         if ($extended !== null) {
             return $extended;
         }
 
-        if ($this->Parent()->exists()) {
-            $parent = $this->Parent();
-            if ($parent->hasExtension(Versioned::class)) {
-                return $parent->canArchive($member);
-            } else {
-                return $parent->canDelete($member);
-            }
-        }
 
         return (Permission::check('CMS_ACCESS', 'any', $member)) ? true : null;
     }

--- a/src/Model/VideoSlide.php
+++ b/src/Model/VideoSlide.php
@@ -45,6 +45,7 @@ class VideoSlide extends Slide
      */
     private static $has_one = [
         'Video' => File::class,
+        // @phpstan-ignore class.notFound
         'EmbedVideo' => EmbedObject::class,
     ];
 

--- a/src/Model/VideoSlide.php
+++ b/src/Model/VideoSlide.php
@@ -4,6 +4,10 @@ namespace Dynamic\Carousel\Model;
 
 use SilverStripe\Assets\File;
 use SilverStripe\Forms\FieldList;
+use nathancox\EmbedField\Forms\EmbedField;
+use nathancox\EmbedField\Model\EmbedObject;
+use UncleCheese\DisplayLogic\Forms\Wrapper;
+use SilverStripe\AssetAdmin\Forms\UploadField;
 
 /**
  * Class \Dynamic\Carousel\Model\VideoSlide
@@ -41,6 +45,7 @@ class VideoSlide extends Slide
      */
     private static $has_one = [
         'Video' => File::class,
+        'EmbedVideo' => EmbedObject::class,
     ];
 
     /**
@@ -56,7 +61,38 @@ class VideoSlide extends Slide
     public function getCMSFields(): FieldList
     {
         $this->beforeUpdateCMSFields(function (FieldList $fields) {
-            //$fields->
+            // Remvove fields
+            $fields->removeByName([
+                'EmbedVideoID',
+                'Video',
+            ]);
+
+            $fields->insertBefore(
+                'Content',
+                $fields->dataFieldByName('VideoType')
+            );
+
+            // Native video
+            $uploadVideo = UploadField::create('Video', 'Upload video')
+                ->setFolderName('Uploads/Carousel/Videos');
+
+            $fields->insertAfter(
+                'VideoType',
+                $uploadVideo
+            );
+
+            // Embed video
+            // @phpstan-ignore class.notFound
+            $embedVideo = Wrapper::create(EmbedField::create('EmbedVideoID', 'Embed video'));
+
+            $fields->insertAfter(
+                'VideoType',
+                $embedVideo
+            );
+
+            //
+            $uploadVideo->displayIf("VideoType")->isEqualTo("Native");
+            $embedVideo->displayIf("VideoType")->isEqualTo("Embed");
         });
 
         return parent::getCMSFields();


### PR DESCRIPTION
Upgrades the module to SilverStripe 6 compatibility.

## Changes

- Updated PHP requirement to ^8.1
- Updated silverstripe/linkfield: ^4 -> ^5
- Updated silverstripe/recipe-cms: ^5 -> ^6
- Updated symbiote/silverstripe-gridfieldextensions: ^4 -> ^5
- Updated unclecheese/display-logic: ^3 -> ^4
- Updated silverstripe/recipe-testing: ^3 -> ^6 (dev)
- Updated branch-alias to 3.x-dev

This prepares the module for the v3.0.0 release.