### PR TITLE
Upgrade to SilverStripe 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^8.1",
         "fromholdio/silverstripe-embedfield": "^5.1",
-        "jonom/focuspoint": "^5",
+        "jonom/focuspoint": "^6",
         "silverstripe/linkfield": "^5",
         "silverstripe/recipe-cms": "^6",
         "symbiote/silverstripe-gridfieldextensions": "^5",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "silverstripe/linkfield": "^5",
         "silverstripe/recipe-cms": "^6",
         "symbiote/silverstripe-gridfieldextensions": "^5",
-        "unclecheese/display-logic": "^3.0"
+        "unclecheese/display-logic": "^4.0"
     },
     "require-dev": {
         "dnadesign/silverstripe-elemental": "^6",
@@ -38,7 +38,7 @@
     ],
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0.x-dev"
+            "dev-main": "3.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,16 +8,17 @@
         "CMS"
     ],
     "require": {
+        "php": "^8.1",
         "jonom/focuspoint": "^5",
         "nathancox/embedfield": "^3.0",
-        "silverstripe/linkfield": "^4.0",
-        "silverstripe/recipe-cms": "^5.0",
-        "symbiote/silverstripe-gridfieldextensions": "^4",
+        "silverstripe/linkfield": "^5",
+        "silverstripe/recipe-cms": "^6",
+        "symbiote/silverstripe-gridfieldextensions": "^5",
         "unclecheese/display-logic": "^3.0"
     },
     "require-dev": {
-        "dnadesign/silverstripe-elemental": "^5",
-        "silverstripe/recipe-testing": "^3",
+        "dnadesign/silverstripe-elemental": "^6",
+        "silverstripe/recipe-testing": "^4",
         "silverstripe/standards": "^1",
         "squizlabs/php_codesniffer": "^3"
     },
@@ -37,7 +38,7 @@
     ],
     "extra": {
         "branch-alias": {
-            "dev-main": "2.x-dev"
+            "dev-master": "3.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     ],
     "require": {
         "php": "^8.1",
+        "fromholdio/silverstripe-embedfield": "^5.1",
         "jonom/focuspoint": "^5",
-        "nathancox/embedfield": "^3.0",
         "silverstripe/linkfield": "^5",
         "silverstripe/recipe-cms": "^6",
         "symbiote/silverstripe-gridfieldextensions": "^5",

--- a/src/Extension/CarouselPageExtension.php
+++ b/src/Extension/CarouselPageExtension.php
@@ -5,7 +5,7 @@ namespace Dynamic\Carousel\Extension;
 use SilverStripe\View\SSViewer;
 use Dynamic\Carousel\Model\Slide;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\CompositeField;
@@ -29,7 +29,7 @@ use SilverStripe\Forms\GridField\GridFieldAddExistingAutocompleter;
  * @property int $Interval
  * @method \SilverStripe\ORM\ManyManyThroughList|Slide[] Slides()
  */
-class CarouselPageExtension extends DataExtension
+class CarouselPageExtension extends Extension
 {
     /**
      * @var array

--- a/src/Extension/CarouselPageExtension.php
+++ b/src/Extension/CarouselPageExtension.php
@@ -164,12 +164,11 @@ class CarouselPageExtension extends Extension
     /**
      * @return void
      */
-    public function onBeforeWrite()
+    protected function onBeforeWrite()
     {
         if (!$this->getOwner()->Interval || $this->getOwner()->Interval < 0) {
             $this->getOwner()->Interval = self::$defaults['Interval'];
         }
-        parent::onBeforeWrite();
     }
 
     /**

--- a/src/Model/VideoSlide.php
+++ b/src/Model/VideoSlide.php
@@ -45,7 +45,6 @@ class VideoSlide extends Slide
      */
     private static $has_one = [
         'Video' => File::class,
-        // @phpstan-ignore class.notFound
         'EmbedVideo' => EmbedObject::class,
     ];
 
@@ -83,7 +82,6 @@ class VideoSlide extends Slide
             );
 
             // Embed video
-            // @phpstan-ignore class.notFound
             $embedVideo = Wrapper::create(EmbedField::create('EmbedVideoID', 'Embed video'));
 
             $fields->insertAfter(

--- a/src/Model/VideoSlide.php
+++ b/src/Model/VideoSlide.php
@@ -4,8 +4,8 @@ namespace Dynamic\Carousel\Model;
 
 use SilverStripe\Assets\File;
 use SilverStripe\Forms\FieldList;
-use nathancox\EmbedField\Forms\EmbedField;
-use nathancox\EmbedField\Model\EmbedObject;
+use Fromholdio\EmbedField\Forms\EmbedField;
+use Fromholdio\EmbedField\Model\EmbedObject;
 use UncleCheese\DisplayLogic\Forms\Wrapper;
 use SilverStripe\AssetAdmin\Forms\UploadField;
 


### PR DESCRIPTION
Upgrades the module to SilverStripe 6 compatibility.

## Changes

- Updated PHP requirement to ^8.1
- Updated all core dependencies to SS6-compatible versions:
  - silverstripe/linkfield: ^4 → ^5
  - silverstripe/recipe-cms: ^5 → ^6
  - silverstripe/recipe-testing: ^3 → ^4
  - dnadesign/silverstripe-elemental: ^5 → ^6
  - symbiote/silverstripe-gridfieldextensions: ^4 → ^5
- Replaced deprecated `SilverStripe\ORM\DataExtension` with `SilverStripe\Core\Extension`
- Set branch-alias to dev-master: 3.0.x-dev

## Testing

- ✅ PHPCS: Clean

This prepares the module for the 3.0.0 release.