### PR TITLE
fix(#128): align TextCheckboxGroupField call with BaseElement pattern

### DIFF
--- a/src/Model/Slide.php
+++ b/src/Model/Slide.php
@@ -108,7 +108,8 @@ class Slide extends DataObject
             if (class_exists(TextCheckboxGroupField::class)) {
                 $fields->replaceField(
                     'Title',
-                    TextCheckboxGroupField::create('Title')
+                    TextCheckboxGroupField::create()
+                        ->setName('Title')
                         ->setTitle($this->fieldLabel('Title'))
                 );
             } else {


### PR DESCRIPTION
## Problem

`Slide::getCMSFields()` called `TextCheckboxGroupField::create('Title')`, passing `'Title'` as the `\$title` (label) argument. `TextCheckboxGroupField::__construct(\$title = null)` — the first arg is the label, not the name. The composite field therefore had no name set on the FieldList, diverging from the `BaseElement` pattern.

## Fix

Match `BaseElement` exactly:

```php
TextCheckboxGroupField::create()
    ->setName('Title')
    ->setTitle($this->fieldLabel('Title'))
```

The "Displayed" checkbox and its `ShowTitle` binding were already correct — this only fixes the composite field's FieldList name, ensuring `dataFieldByName('Title')` resolves correctly after replacement.

## Note on amilliondreamz data

The reported symptom (slide title not showing) is a data issue — `ShowTitle = 0` on existing slides. An editor needs to check "Displayed" in the CMS for those slides, or a targeted SQL fix can be applied. Both `Slide` and `BaseElement` have `ShowTitle` defaulting to `false` — this is consistent behaviour, not a bug.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XDwTrKeXXWPeuN4gP82SnN